### PR TITLE
[Feature] Added a parameter to add colons to the MAC output

### DIFF
--- a/src/mac_changer.py
+++ b/src/mac_changer.py
@@ -35,7 +35,17 @@ def increment_octet(octets: str) -> str:
     return incremented_hex
 
 
-def new_mac_address():
+def add_colons_to_mac(mac: str) -> str:
+    """Format a MAC address string by adding colons between every two characters.
+    Param:
+        mac (str): The MAC address string without colons.
+    Returns:
+        str: The formatted MAC address with colons.
+    """
+    return ":".join(mac[i : i + 2] for i in range(0, len(mac), 2))
+
+
+def new_mac_address(colons=True) -> str:
     """Generate a new MAC address by incrementing the last three octets of the current MAC address.
     Returns:
         str: The new MAC address in hexadecimal format.
@@ -45,4 +55,6 @@ def new_mac_address():
     last_three_octets = get_octets_from_range(mac_address, 3, 6)
     incremented_last_octets = increment_octet(last_three_octets)
     new_mac = first_three_octets + incremented_last_octets
+    if colons:
+        new_mac = add_colons_to_mac(new_mac)
     return new_mac

--- a/tests/test_mac_changer.py
+++ b/tests/test_mac_changer.py
@@ -22,6 +22,12 @@ def test_octets_incrementer():
 
 
 def test_new_mac_address():
-    new_address = new_mac_address()
+    new_address = new_mac_address(False)
     assert len(new_address) == 12
     assert new_address != mac_address
+
+def test_new_mac_address_with_colons():
+    new_address = new_mac_address(True)
+    assert len(new_address) == 17
+    assert new_address.count(":") == 5
+    assert new_address.replace(":", "") != mac_address


### PR DESCRIPTION
# Feature Pull Request

## Feature Description
Added a paramater to add colons to the MAC address output.

## Implementation Details
- Added a function to put a colon in between each octet.

## API Changes
The `new_mac_address` function has an option parameter. By default, the output contains colons.

## Related Issues
N/A

## Checklist
- [x] Code follows the project's style guidelines
- [x] All new and existing tests pass
- [x] New unit tests were added for the feature
- [x] Integration tests cover the new functionality
- [x] Documentation was updated to reflect the new feature
